### PR TITLE
Fix typo in boulderdash

### DIFF
--- a/examples/gridphysics/boulderdash.txt
+++ b/examples/gridphysics/boulderdash.txt
@@ -20,7 +20,7 @@ BasicGame
 		b > butterfly
 
 	InteractionSet
-		dirt avatar swrod > killSprite
+		dirt avatar sword > killSprite
 		diamond avatar > collectResource  scoreChange=2
 		moving wall boulder > stepBack
 


### PR DESCRIPTION
The sprite 'sword' was misspelled as 'swrod' in one of the InteractionSet rules. Since the typo effectively made that rule inactive, this changes the gameplay.