### PR TITLE
Warn when an interaction entry references an unknown sprite

### DIFF
--- a/src/core/VGDLParser.java
+++ b/src/core/VGDLParser.java
@@ -334,7 +334,10 @@ public class VGDLParser
                         }else if (ic.object1.equalsIgnoreCase("TIME") ||
                                    obj2Str.equalsIgnoreCase("TIME")) {
                             game.addTimeEffect((TimeEffect) ef);
-                        }
+   		        //unknown sprite other than an EOS or TIME effect is an error
+                        }else {
+			    System.out.println("[PARSE ERROR] interaction entry references unknown sprite: " + ic.line);
+			}
                     }
 
                     if(VERBOSE_PARSER)


### PR DESCRIPTION
Currently, interaction entries that reference an unknown sprite are silently ignored (the interaction entry is skipped). Let's print a "PARSE ERROR" warning when skipping it, so things like issue #28 and the issue fixed by 687827dfc69ac886c9b5b9d7e02c609888fdde71 don't go unnoticed. Arguably, parse errors should generate an exception, but existing cases in VGDLParser do it this way, so I followed that.

I think longer-term, VGDLParser should be reworked to do more proper parsing with input validation. Especially if it will become more common in the future for people to experiment with writing their own VGDL definitions, there are many cases with the current parser where syntax mistakes won't produce a visible error, and instead users will silently get unexpected behavior.