### PR TITLE
Update bounds during backup in the vanilla MCTS

### DIFF
--- a/src/tracks/multiPlayer/advanced/sampleMCTS/SingleTreeNode.java
+++ b/src/tracks/multiPlayer/advanced/sampleMCTS/SingleTreeNode.java
@@ -243,6 +243,12 @@ public class SingleTreeNode
         {
             n.nVisits++;
             n.totValue += result;
+            if (result < n.bounds[0]) {
+                n.bounds[0] = result;
+            }
+            if (result > n.bounds[1]) {
+                n.bounds[1] = result;
+            }
             n = n.parent;
         }
     }

--- a/src/tracks/multiPlayer/deprecated/sampleMCTS/SingleTreeNode.java
+++ b/src/tracks/multiPlayer/deprecated/sampleMCTS/SingleTreeNode.java
@@ -273,6 +273,12 @@ public class SingleTreeNode
         {
             n.nVisits++;
             n.totValue += result;
+            if (result < n.bounds[0]) {
+                n.bounds[0] = result;
+            }
+            if (result > n.bounds[1]) {
+                n.bounds[1] = result;
+            }
             n = n.parent;
         }
     }

--- a/src/tracks/singlePlayer/advanced/sampleMCTS/SingleTreeNode.java
+++ b/src/tracks/singlePlayer/advanced/sampleMCTS/SingleTreeNode.java
@@ -207,6 +207,12 @@ public class SingleTreeNode
         {
             n.nVisits++;
             n.totValue += result;
+            if (result < n.bounds[0]) {
+                n.bounds[0] = result;
+            }
+            if (result > n.bounds[1]) {
+                n.bounds[1] = result;
+            }
             n = n.parent;
         }
     }

--- a/src/tracks/singlePlayer/deprecated/sampleMCTS/SingleTreeNode.java
+++ b/src/tracks/singlePlayer/deprecated/sampleMCTS/SingleTreeNode.java
@@ -244,6 +244,12 @@ public class SingleTreeNode
         {
             n.nVisits++;
             n.totValue += result;
+            if (result < n.bounds[0]) {
+                n.bounds[0] = result;
+            }
+            if (result > n.bounds[1]) {
+                n.bounds[1] = result;
+            }
             n = n.parent;
         }
     }


### PR DESCRIPTION
Update bounds during backup to ensure valid bounds during UCT on all vanilla MCTS. More details on the problem can be found at https://groups.google.com/forum/#!topic/the-general-video-game-competition/_ws6nxsj_5k