### PR TITLE
Simplify heuristics' constructor

### DIFF
--- a/src/tracks/multiPlayer/advanced/sampleRHEA/Agent.java
+++ b/src/tracks/multiPlayer/advanced/sampleRHEA/Agent.java
@@ -58,7 +58,7 @@ public class Agent extends AbstractMultiPlayer {
      */
     public Agent(StateObservationMulti stateObs, ElapsedCpuTimer elapsedTimer, int playerID) {
         randomGenerator = new Random();
-        heuristic = new WinScoreHeuristic(stateObs);
+        heuristic = new WinScoreHeuristic();
         this.timer = elapsedTimer;
 
         // Get multiplayer game parameters

--- a/src/tracks/multiPlayer/advanced/sampleRS/Agent.java
+++ b/src/tracks/multiPlayer/advanced/sampleRS/Agent.java
@@ -43,7 +43,7 @@ public class Agent extends AbstractMultiPlayer {
      */
     public Agent(StateObservationMulti stateObs, ElapsedCpuTimer elapsedTimer, int playerID) {
         randomGenerator = new Random();
-        heuristic = new WinScoreHeuristic(stateObs);
+        heuristic = new WinScoreHeuristic();
         this.timer = elapsedTimer;
 
         // Get multiplayer game parameters

--- a/src/tracks/multiPlayer/deprecated/sampleGA/Agent.java
+++ b/src/tracks/multiPlayer/deprecated/sampleGA/Agent.java
@@ -255,7 +255,7 @@ public class Agent extends AbstractMultiPlayer {
         this.timer = elapsedTimer;
         numSimulations = 0;
 
-        Types.ACTIONS lastGoodAction = microbial(stateObs, SIMULATION_DEPTH, new WinScoreHeuristic(stateObs), 100);
+        Types.ACTIONS lastGoodAction = microbial(stateObs, SIMULATION_DEPTH, new WinScoreHeuristic(), 100);
 
         return lastGoodAction;
     }

--- a/src/tracks/multiPlayer/simple/sampleOneStepLookAhead/Agent.java
+++ b/src/tracks/multiPlayer/simple/sampleOneStepLookAhead/Agent.java
@@ -53,7 +53,7 @@ public class Agent extends AbstractMultiPlayer {
 
         //A random non-suicidal action by the opponent.
         Types.ACTIONS oppAction = getOppNotLosingAction(stateObs, id, oppID);
-        SimpleStateHeuristic heuristic =  new SimpleStateHeuristic(stateObs);
+        SimpleStateHeuristic heuristic = new SimpleStateHeuristic();
 
         for (Types.ACTIONS action : stateObs.getAvailableActions(id)) {
 

--- a/src/tracks/multiPlayer/tools/heuristics/SimpleStateHeuristic.java
+++ b/src/tracks/multiPlayer/tools/heuristics/SimpleStateHeuristic.java
@@ -17,12 +17,6 @@ import java.util.HashMap;
  */
 public class SimpleStateHeuristic extends StateHeuristicMulti {
 
-    double initialNpcCounter = 0;
-
-    public SimpleStateHeuristic(StateObservationMulti stateObs) {
-
-    }
-
     public double evaluateState(StateObservationMulti stateObs, int playerID) {
         Vector2d avatarPosition = stateObs.getAvatarPosition(playerID);
         ArrayList<Observation>[] npcPositions = stateObs.getNPCPositions(avatarPosition);

--- a/src/tracks/multiPlayer/tools/heuristics/WinScoreHeuristic.java
+++ b/src/tracks/multiPlayer/tools/heuristics/WinScoreHeuristic.java
@@ -15,12 +15,6 @@ public class WinScoreHeuristic extends StateHeuristicMulti {
     private static final double HUGE_NEGATIVE = -1000.0;
     private static final double HUGE_POSITIVE =  1000.0;
 
-    double initialNpcCounter = 0;
-
-    public WinScoreHeuristic(StateObservationMulti stateObs) {
-
-    }
-
     public double evaluateState(StateObservationMulti stateObs, int playerID) {
         boolean gameOver = stateObs.isGameOver();
         Types.WINNER win = stateObs.getMultiGameWinner()[playerID];

--- a/src/tracks/singlePlayer/advanced/sampleRHEA/Agent.java
+++ b/src/tracks/singlePlayer/advanced/sampleRHEA/Agent.java
@@ -53,7 +53,7 @@ public class Agent extends AbstractPlayer {
      */
     public Agent(StateObservation stateObs, ElapsedCpuTimer elapsedTimer) {
         randomGenerator = new Random();
-        heuristic = new WinScoreHeuristic(stateObs);
+        heuristic = new WinScoreHeuristic();
         this.timer = elapsedTimer;
     }
 

--- a/src/tracks/singlePlayer/advanced/sampleRS/Agent.java
+++ b/src/tracks/singlePlayer/advanced/sampleRS/Agent.java
@@ -40,7 +40,7 @@ public class Agent extends AbstractPlayer {
      */
     public Agent(StateObservation stateObs, ElapsedCpuTimer elapsedTimer) {
         randomGenerator = new Random();
-        heuristic = new WinScoreHeuristic(stateObs);
+        heuristic = new WinScoreHeuristic();
         this.timer = elapsedTimer;
 
         // INITIALISE POPULATION

--- a/src/tracks/singlePlayer/deprecated/sampleGA/Agent.java
+++ b/src/tracks/singlePlayer/deprecated/sampleGA/Agent.java
@@ -206,7 +206,7 @@ public class Agent extends AbstractPlayer {
         this.timer = elapsedTimer;
         numSimulations = 0;
 
-        Types.ACTIONS lastGoodAction = microbial(stateObs, SIMULATION_DEPTH, new WinScoreHeuristic(stateObs), 100);
+        Types.ACTIONS lastGoodAction = microbial(stateObs, SIMULATION_DEPTH, new WinScoreHeuristic(), 100);
 
         return lastGoodAction;
     }

--- a/src/tracks/singlePlayer/simple/sampleonesteplookahead/Agent.java
+++ b/src/tracks/singlePlayer/simple/sampleonesteplookahead/Agent.java
@@ -41,7 +41,7 @@ public class Agent extends AbstractPlayer {
 
         Types.ACTIONS bestAction = null;
         double maxQ = Double.NEGATIVE_INFINITY;
-        SimpleStateHeuristic heuristic =  new SimpleStateHeuristic(stateObs);
+        SimpleStateHeuristic heuristic = new SimpleStateHeuristic();
         for (Types.ACTIONS action : stateObs.getAvailableActions()) {
 
             StateObservation stCopy = stateObs.copy();

--- a/src/tracks/singlePlayer/tools/Heuristics/SimpleStateHeuristic.java
+++ b/src/tracks/singlePlayer/tools/Heuristics/SimpleStateHeuristic.java
@@ -17,12 +17,6 @@ import tools.Vector2d;
  */
 public class SimpleStateHeuristic extends StateHeuristic {
 
-    double initialNpcCounter = 0;
-
-    public SimpleStateHeuristic(StateObservation stateObs) {
-
-    }
-
     public double evaluateState(StateObservation stateObs) {
         Vector2d avatarPosition = stateObs.getAvatarPosition();
         ArrayList<Observation>[] npcPositions = stateObs.getNPCPositions(avatarPosition);

--- a/src/tracks/singlePlayer/tools/Heuristics/WinScoreHeuristic.java
+++ b/src/tracks/singlePlayer/tools/Heuristics/WinScoreHeuristic.java
@@ -15,12 +15,6 @@ public class WinScoreHeuristic extends StateHeuristic {
     private static final double HUGE_NEGATIVE = -1000.0;
     private static final double HUGE_POSITIVE =  1000.0;
 
-    double initialNpcCounter = 0;
-
-    public WinScoreHeuristic(StateObservation stateObs) {
-
-    }
-
     public double evaluateState(StateObservation stateObs) {
         boolean gameOver = stateObs.isGameOver();
         Types.WINNER win = stateObs.getGameWinner();


### PR DESCRIPTION
Hi! This pull request proposes to change the constructor of the Heuristic classes. 

Currently, all Heuristic classes have a constructor with a `StateObservation*` parameter. **This parameter is not used**, and is confusing (at least to me) particularly because it makes sense that an Heuristic class requires a `StateObservation*`, however the evaluated state is the one provided through the method (`evaluateState`) parameter.

This pull request removes the constructor and the argument from all instantiations of all Heuristic classes.

\* - `StateObservation` for single-player and `StateObservationMulti` for multi-player