### PR TITLE
Teardown does not happen for second player

### DIFF
--- a/src/tracks/ArcadeMachine.java
+++ b/src/tracks/ArcadeMachine.java
@@ -905,7 +905,6 @@ public class ArcadeMachine {
 
             if (VERBOSE)
             System.out.println("Controller tear down time: " + timeTaken + " ms.");
-            return true;
         }
 
         return true;


### PR DESCRIPTION
The early `return true;` prevents `resultMulti` from being called on the second agent.