### PR TITLE
set tcpNoDelay flag

### DIFF
--- a/clients/GVGAI-JavaClient/src/utils/IOSocket.java
+++ b/clients/GVGAI-JavaClient/src/utils/IOSocket.java
@@ -37,6 +37,8 @@ public class IOSocket extends IO {
             {
                 try{
                     socket = new Socket(hostname, port);
+                    // Send immediately. (Disable Nagle's algorithm)
+                    socket.setTcpNoDelay(true);
                     connected = true;
                     System.out.println("Client connected to server [OK]");
                 }catch (ConnectException e) {

--- a/clients/GVGAI-PythonClient/src/utils/IOSocket.py
+++ b/clients/GVGAI-PythonClient/src/utils/IOSocket.py
@@ -29,6 +29,7 @@ class IOSocket:
         while not self.connected:
             try:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1) # Send immediately. (Disable Nagle's algorithm)
                 self.socket.connect((self.hostname, self.port))
                 self.connected = True
                 print ("Client connected to server [OK]")

--- a/src/tracks/singleLearning/utils/SocketComm.java
+++ b/src/tracks/singleLearning/utils/SocketComm.java
@@ -42,6 +42,8 @@ public class SocketComm extends Comm {
             while (socket == null) {
                 ServerSocket serverSocket = new ServerSocket(port);
                 socket = serverSocket.accept();
+                // Send immediately. (Disable Nagle's algorithm)
+                socket.setTcpNoDelay(true);
             }
 
 


### PR DESCRIPTION
Profiling the learning server and client showed that both are spending almost all their time waiting for messages.
I found that setting TCP_NODELAY increased speed significantly.
The time the java client has to wait for a new observation: 
With JSON only:    
Original:  40-50 ms     
TCP No Delay: 1-3 ms
With BOTH:           
Original:  60-90 ms     
TCP No Delay: 13-17 ms
For these measurements, I set the competition_parameters.DELAY to zero.
The times are similar in case of the python client.
I only tested on Linux.

Explanation:
https://www.extrahop.com/company/blog/2016/tcp-nodelay-nagle-quickack-best-practices/
Quote from the article:
"Some contexts where Nagle's algorithm won't help and TCP_NODELAY should be enabled are:
Highly interactive applications that communicate with a central server (Citrix, networked video games, etc)"